### PR TITLE
refactor(filters): improve locators, constants, and HeaderChangeLangBtn behavior

### DIFF
--- a/component/client/HeaderChangeLangBtn.ts
+++ b/component/client/HeaderChangeLangBtn.ts
@@ -31,6 +31,7 @@ export class HeaderChangeLangBtn extends BaseComponent {
 
     async waitForHeaderChangeLangBtnVisible(): Promise<void> {
         await allure.step(`Check if Change Language Btn is visible`, async () => {
+            await this.image.click();
             await this.waitIsVisible(this.menuLocator);
         })
     }

--- a/component/client/filters/FilterButtonComponent.ts
+++ b/component/client/filters/FilterButtonComponent.ts
@@ -8,6 +8,7 @@ import { step } from 'allure-js-commons';
  * Represents the "Filters" button that opens the filters panel.
  */
 export class FilterButtonComponent extends BaseComponent {
+    private container: Locator;
     private button: Locator;
     private menuContainer: Locator;
     private badgeLocator: Locator;
@@ -15,9 +16,10 @@ export class FilterButtonComponent extends BaseComponent {
 
     constructor(page: Page, parent: Locator) {
         super(page, parent);
-        this.button = this.parent.locator('button:has-text("Фільтри")');
-        this.menuContainer = this.page.locator('.MuiBox-root.css-yd8sa2');
-        this.badgeLocator = this.page.locator('.MuiBadge-badge');
+        this.container = this.page.locator('[data-testid="ControlPanel"]');
+        this.button = this.container.locator('button:has(span.filtersLabel)');
+        this.menuContainer = this.page.locator('[data-testid="ControlPanel-controlsColumn"]');
+        this.badgeLocator = this.container.locator('.MuiBadge-root .MuiBadge-badge');
         this.badge = new FilterBadgeComponent(page, this.button);
     }
 

--- a/component/client/filters/FilterListItemComponent.ts
+++ b/component/client/filters/FilterListItemComponent.ts
@@ -3,47 +3,46 @@ import { BaseComponent } from '../BaseComponent';
 import { FilterDropdownComponent } from './FilterDropdownComponent';
 import { FilterChipComponent } from './FilterChipComponent';
 import { step } from 'allure-js-commons';
+import {FilterNames} from "../../../data/filter.constants";
 
 /**
  * Represents a single filter item in the Filters menu (e.g., Genre, Category, Author).
  * Supports opening and closing dropdowns and retrieving related components.
  */
 export class FilterListItemComponent extends BaseComponent {
-    private filterLabel: Locator;
-    private root: Locator;
+    private readonly testId: string;
+    private container: Locator;
     private title: Locator;
-    private dropdownIcon: Locator;
-    private popup: Locator;
+    private dropdown: Locator;
 
-    constructor(page: Page, parent: Locator, filterName: string) {
+    constructor(page: Page, parent: Locator, filter: FilterNames) {
         super(page, parent);
-        this.filterLabel = this.parent.locator(`p:has-text("${filterName}")`);
-        this.root = this.filterLabel.locator('xpath=ancestor::div[contains(@class, "MuiBox-root")][1]');
-        this.title = this.root.locator('p');
-        this.dropdownIcon = this.root.locator('img[alt="dropdown"], svg[width="16"]').first();
-        this.popup = this.page.locator('.MuiPaper-root.MuiPopover-paper');
+        this.testId = filter;
+        this.container = this.page.locator(`[data-testid="${this.testId}"]`);
+        this.title = this.container.locator('p');
+        this.dropdown = this.page.locator('.MuiPaper-root.MuiPopover-paper');
     }
 
-    async getTitle(): Promise<string> {
+    async getTitleText(): Promise<string> {
         return await step(`Get title of filter`, async () => {
             return (await this.title.textContent())?.trim() || '';
         });
     }
 
     async openDropdown(): Promise<FilterDropdownComponent> {
-        return await step(`Open dropdown for filter`, async () => {
-            await this.dropdownIcon.click({ force: true });
-            return new FilterDropdownComponent(this.page, this.popup);
+        return await step('Open dropdown for filter', async () => {
+            await this.container.click();
+            return new FilterDropdownComponent(this.page, this.dropdown);
         });
     }
 
     getChip(): FilterChipComponent {
-        return new FilterChipComponent(this.page, this.root);
+        return new FilterChipComponent(this.page, this.container);
     }
 
     async isDropdownVisible(): Promise<boolean> {
         return await step(`Check if dropdown is visible`, async () => {
-            return this.popup.isVisible();
+            return this.dropdown.isVisible();
         });
     }
 }

--- a/component/client/filters/FilterOptionItemComponent.ts
+++ b/component/client/filters/FilterOptionItemComponent.ts
@@ -1,37 +1,39 @@
 import { Locator, Page } from '@playwright/test';
 import { BaseComponent } from '../BaseComponent';
 import { step } from 'allure-js-commons';
+import {FilterOptions} from "../../../data/filter.constants";
 
 /**
  * Represents an option item inside a filter dropdown menu
  */
 export class FilterOptionItemComponent extends BaseComponent {
+    private checkboxContainer: Locator;
     private checkbox: Locator;
-    private label: Locator;
+    private labelText: Locator;
 
-    constructor(page: Page, parent: Locator, optionName: string) {
+    constructor(page: Page, parent: Locator, optionName: FilterOptions) {
         super(page, parent);
 
-        const root = this.parent.locator(`.MuiBox-root.css-b82atk:has-text("${optionName}")`);
-        this.checkbox = root.locator('input[type="checkbox"]');
-        this.label = root.locator('p');
+        this.checkboxContainer = this.parent.locator(`p:has-text("${optionName}")`).locator('..');
+        this.checkbox = this.checkboxContainer.locator('input[type="checkbox"]');
+        this.labelText = this.checkbox.locator('p');
     }
 
     async getLabelText(): Promise<string> {
         return await step(`Get label text of filter option`, async () => {
-            return (await this.label.textContent())?.trim() || '';
+            return (await this.labelText.textContent())?.trim() || '';
         });
     }
 
     async isVisible(): Promise<boolean> {
         return await step(`Check if option is visible`, async () => {
-            return this.label.isVisible();
+            return this.labelText.isVisible();
         });
     }
 
     async select(): Promise<void> {
         return await step(`Select filter option`, async () => {
-            await this.label.click();
+            await this.checkbox.click();
         });
     }
 
@@ -44,7 +46,7 @@ export class FilterOptionItemComponent extends BaseComponent {
     async deselect(): Promise<void> {
         return await step(`Deselect filter option`, async () => {
             if (await this.checkbox.isChecked()) {
-                await this.label.click();
+                await this.checkbox.click();
             }
         });
     }

--- a/component/client/filters/FilterYearItemComponent.ts
+++ b/component/client/filters/FilterYearItemComponent.ts
@@ -1,62 +1,49 @@
 import { Locator, Page } from '@playwright/test';
 import { BaseComponent } from '../BaseComponent';
+import { YearInputIndex } from "../../../data/filter.constants";
 import { step } from 'allure-js-commons';
-
 /**
  * Represents the "Year" filter item with range inputs ("From" / "To").
  * Allows opening, setting, clearing, and closing the dropdown.
  */
 export class FilterYearItemComponent extends BaseComponent {
+    private container: Locator;
     private dropdownPanel: Locator;
-    private root: Locator;
-    private title: Locator;
-    private dropdownIcon: Locator;
+    private clearFilterButton: Locator;
     private fromInput: Locator;
     private toInput: Locator;
-    private clearButton: Locator;
 
-    constructor(page: Page, parent: Locator, filterName: string) {
+    constructor(page: Page, parent: Locator) {
         super(page, parent);
-
-        const filterLabel = this.parent.locator(`p:has-text("${filterName}")`);
-        this.root = filterLabel.locator('xpath=ancestor::div[contains(@class, "MuiBox-root")][1]');
-        this.title = this.root.locator('p');
-
-        this.dropdownIcon = this.root.locator('img[alt="dropdown"], svg[width="16"]').first();
+        this.container = this.page.locator('[data-testid="MusicTableFilters-year"]');
         this.dropdownPanel = this.page.locator('.MuiPaper-root.MuiPopover-paper');
+        this.clearFilterButton = this.page.locator('div[aria-label="clear"]');
+        this.fromInput = this.dropdownPanel.locator('.MuiTextField-root input').nth(YearInputIndex.FROM);
+        this.toInput = this.dropdownPanel.locator('.MuiTextField-root input').nth(YearInputIndex.TO);
+    }
 
-        const inputs = this.dropdownPanel.locator('.MuiTextField-root input');
-        this.fromInput = inputs.nth(0);
-        this.toInput = inputs.nth(1);
+    private async getHelperByInput(input: Locator): Promise<Locator> {
+        const id = await input.getAttribute('aria-describedby');
+        return this.page.locator(`#${id}`);
+    }
 
-        this.clearButton = this.page.locator('div[aria-label="trash"]');
+    private async getFromHelper(): Promise<Locator> {
+        return this.getHelperByInput(this.fromInput);
+    }
+
+    private async getToHelper(): Promise<Locator> {
+        return this.getHelperByInput(this.toInput);
     }
 
     async openDropdown(): Promise<void> {
         return await step('Open Year dropdown', async () => {
-            await this.dropdownIcon.click();
+            await this.container.click();
         });
     }
 
-    async closeDropdown(): Promise<void> {
-        return await step('Close Year dropdown', async () => {
-            await this.dropdownIcon.click();
-        });
-    }
-
-    async isDropdownVisible(): Promise<boolean> {
+    async isVisible(): Promise<boolean> {
         return await step('Check if Year dropdown is visible', async () => {
             return this.dropdownPanel.isVisible();
-        });
-    }
-
-    async setRange(from: string, to: string): Promise<void> {
-        return await step(`Set year range: From = ${from}, To = ${to}`, async () => {
-            if (!(await this.isDropdownVisible())) {
-                await this.openDropdown();
-            }
-            await this.fromInput.fill(from);
-            await this.toInput.fill(to);
         });
     }
 
@@ -69,27 +56,6 @@ export class FilterYearItemComponent extends BaseComponent {
     async getToValue(): Promise<string> {
         return await step('Get value from "To" input', async () => {
             return this.toInput.inputValue();
-        });
-    }
-
-    async clear(): Promise<void> {
-        return await step('Click "Clear filter" (trash) button', async () => {
-            await this.clearButton.click();
-        });
-    }
-
-    async isValidationMessageVisible(field: 'Від' | 'До'): Promise<boolean> {
-        return await step(`Check if validation message visible for "${field}"`, async () => {
-            const message = this.page.locator(`p#${field}-helper-text`);
-            return message.isVisible();
-        });
-    }
-
-    async setYearRange(from: string, to: string): Promise<void> {
-        return await step(`Set Year range directly: ${from} - ${to}`, async () => {
-            await this.openDropdown();
-            await this.fromInput.fill(from);
-            await this.toInput.fill(to);
         });
     }
 
@@ -107,5 +73,38 @@ export class FilterYearItemComponent extends BaseComponent {
             await this.toInput.press('Backspace');
             await this.toInput.fill(value);
         });
+    }
+
+    async setYearRange(from: string, to: string): Promise<void> {
+        return await step(`Set Year range directly: ${from} - ${to}`, async () => {
+            await this.fromInput.fill(from);
+            await this.toInput.fill(to);
+        });
+    }
+
+    async clickClearFilterButton(): Promise<void> {
+        return await step('Click "Clear filter" button', async () => {
+            await this.clearFilterButton.click();
+        });
+    }
+
+    async isFromValidationMessageVisible(): Promise<boolean> {
+        const helper = await this.getFromHelper();
+        return await helper.isVisible();
+    }
+
+    async getFromValidationText(): Promise<string> {
+        const helper = await this.getFromHelper();
+        return (await helper.textContent())?.trim() || '';
+    }
+
+    async isToValidationMessageVisible(): Promise<boolean> {
+        const helper = await this.getToHelper();
+        return await helper.isVisible();
+    }
+
+    async getToValidationText(): Promise<string> {
+        const helper = await this.getToHelper();
+        return (await helper.textContent())?.trim() || '';
     }
 }

--- a/component/client/filters/FiltersMenuComponent.ts
+++ b/component/client/filters/FiltersMenuComponent.ts
@@ -4,29 +4,28 @@ import { FilterListItemComponent } from './FilterListItemComponent';
 import { FilterYearItemComponent } from './FilterYearItemComponent';
 import { FilterChipComponent } from './FilterChipComponent';
 import { step } from 'allure-js-commons';
+import {FilterNames} from "../../../data/filter.constants";
 
 export class FiltersMenuComponent extends BaseComponent {
     activeChip: FilterChipComponent;
     private container: Locator;
     private filterTitles: Locator;
-    private clearAllButton: Locator;
-    private backdrop: Locator;
+    private clearAllFiltersButton: Locator;
 
     constructor(page: Page, parent: Locator) {
         super(page, parent);
-        this.container = this.page.locator('.MuiBox-root.css-yd8sa2');
-        this.filterTitles = this.container.locator('.MuiTypography-root.MuiTypography-body1');
+        this.container = this.page.locator('[data-testid="ControlPanel-controlsColumn"]');
+        this.filterTitles = this.container.locator('[data-testid^="MusicTableFilters-"]');
         this.activeChip = new FilterChipComponent(this.page, this.container);
-        this.clearAllButton = this.page.locator('button:has(svg path[d*="M3 6h18"])');
-        this.backdrop = this.page.locator('.MuiBackdrop-root.MuiModal-backdrop');
+        this.clearAllFiltersButton = this.container.locator('[data-testid="MusicTableFilters-clear"]');
     }
 
-    getListFilter(name: string): FilterListItemComponent {
-        return new FilterListItemComponent(this.page, this.container, name);
+    getListFilter(filterName: FilterNames | string): FilterListItemComponent {
+        return new FilterListItemComponent(this.page, this.container, filterName as FilterNames);
     }
 
-    getYearFilter(name: string): FilterYearItemComponent {
-        return new FilterYearItemComponent(this.page, this.container, name);
+    getYearFilter(): FilterYearItemComponent {
+        return new FilterYearItemComponent(this.page, this.container);
     }
 
     getActiveChip(): FilterChipComponent {
@@ -59,25 +58,21 @@ export class FiltersMenuComponent extends BaseComponent {
 
     async clearAllFilters(): Promise<void> {
         return await step('Clear all selected filters', async () => {
-            if (await this.clearAllButton.isVisible()) {
-                await this.clearAllButton.click();
+            if (await this.clearAllFiltersButton.isVisible()) {
+                await this.clearAllFiltersButton.click();
             }
         });
     }
 
     async isClearAllButtonVisible(): Promise<boolean> {
         return await step('Check if Clear All button is visible', async () => {
-            return await this.clearAllButton.isVisible().catch(() => false);
+            return await this.clearAllFiltersButton.isVisible().catch(() => false);
         });
     }
 
     async closeOpenedDropdown(): Promise<void> {
         return await step('Close open dropdown (click outside)', async () => {
-            if (await this.backdrop.isVisible()) {
-                await this.backdrop.click();
-            } else {
-                await this.page.mouse.click(10, 10);
-            }
+            await this.page.mouse.click(10, 10);
         });
     }
 }

--- a/data/filter.constants.ts
+++ b/data/filter.constants.ts
@@ -1,0 +1,73 @@
+// ============================================================================
+//  FILTERS CONSTANTS
+// Centralized enums and text mappings used across filter-related components & tests.
+// This improves maintainability, localization, and avoids hardcoded UI strings.
+// ============================================================================
+
+// ------------------------- Filter Names -------------------------//
+// --------------data-testid--------------//
+export enum FilterNames {
+    GENRE = 'MusicTableFilters-genre',
+    CATEGORY = 'MusicTableFilters-category',
+    AUTHOR = 'MusicTableFilters-author',
+}
+
+export const FilterNameMap: Record<string, FilterNames> = {
+    'Жанр': FilterNames.GENRE,
+    'Категорія': FilterNames.CATEGORY,
+    'Автор': FilterNames.AUTHOR,
+
+    'Genre': FilterNames.GENRE,
+    'Category': FilterNames.CATEGORY,
+    'Author': FilterNames.AUTHOR,
+};
+
+// ------------------------- Filter Options -------------------------//
+
+export enum FilterOptions {
+    ROMANCE = 'Романс',
+    ART_SONG = 'Мистецька пісня',
+}
+
+// ------------------------- Chip Texts -------------------------//
+/**
+ * UI texts for chips (selection counters) in both languages.
+ */
+export const ChipText = {
+    Ukrainian: {
+        oneSelected: '1 обрано',
+        twoSelected: '2 обрано',
+    },
+    English: {
+        oneSelected: '1 selected',
+        twoSelected: '2 selected',
+    },
+} as const;
+
+// ------------------------- Year Inputs -------------------------//
+/**
+ * Enum representing index positions for "From" and "To" year inputs.
+ * Used when accessing inputs in arrays or locator lists.
+ */
+export enum YearInputIndex {
+    FROM = 0,
+    TO = 1,
+}
+
+// ------------------------- Validation Messages -------------------------//
+/**
+ * Validation messages for Year filter.
+ * Used to avoid hardcoded text in tests and support localization.
+ */
+export const ValidationMessages = {
+    Ukrainian: {
+        FROM_LESS_THAN_MIN: "Число 'Від' не може бути менше ніж 1918",
+        TO_GREATER_THAN_MAX: "Число 'До' не може бути більше ніж 1998",
+        NUMERIC_ONLY: 'Дозволені лише числові значення',
+    },
+    English: {
+        FROM_LESS_THAN_MIN: "The 'From' value cannot be less than 1918",
+        TO_GREATER_THAN_MAX: "The 'To' value cannot exceed 1998",
+        NUMERIC_ONLY: 'Only numeric values are allowed',
+    },
+}

--- a/tests/client/ui.artistry-filters.spec.ts
+++ b/tests/client/ui.artistry-filters.spec.ts
@@ -1,12 +1,21 @@
 import {expect, test} from '../../fixtures/fixturePage';
-import * as allure from 'allure-js-commons';
 import {Language} from "../../data/enums";
+import {FilterNames, FilterOptions, ChipText, ValidationMessages } from "../../data/filter.constants";
+import * as allure from 'allure-js-commons';
+import {FilterYearItemComponent} from "../../component/client/filters/FilterYearItemComponent";
+import {FilterDropdownComponent} from "../../component/client/filters/FilterDropdownComponent";
+import {FilterOptionItemComponent} from "../../component/client/filters/FilterOptionItemComponent";
+import {FilterListItemComponent} from "../../component/client/filters/FilterListItemComponent";
+
 
 test.describe('UI – Artistry Page Filters', () => {
 
+    const currentLanguage = 'Ukrainian';
+
     test.beforeEach(async ({artistryPage}) => {
         await artistryPage.visit();
-        await artistryPage.header.changeLangBtn.selectLanguage(Language.UKRAINIAN);
+        await artistryPage.header.changeLangBtn.waitForHeaderChangeLangBtnVisible();
+        await artistryPage.header.changeLangBtn.selectLanguage(Language[currentLanguage]);
     });
 
     test('TC001 – Open and close Filters menu', async ({artistryPage}) => {
@@ -15,83 +24,129 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.label('severity', 'normal');
         await allure.parameter('Component', 'Filters Menu');
 
-        await allure.step('Open Filters menu', async () => {
-            const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-            expect(await filtersMenu.isVisible()).toBe(true);
+        const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
 
-            await allure.step('Close Filters menu', async () => {
-                await artistryPage.filterButton.closeFiltersMenu();
-                expect(await filtersMenu.isHidden()).toBe(true);
-            });
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Close Filters menu', async () => {
+            await artistryPage.filterButton.closeFiltersMenu();
+            expect(await filtersMenu.isHidden()).toBe(true);
         });
     });
 
-    test('TC002 – Select one filter option', async ({artistryPage}) => {
+    test('TC002 – Select one filter option', async ({ artistryPage }) => {
         await allure.description('Verify selecting a single filter option updates chip and badge count.');
         await allure.label('feature', 'Filters');
         await allure.label('severity', 'normal');
         await allure.parameter('Component', 'Genre Filter');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        expect(await filtersMenu.isVisible()).toBe(true);
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const dropdown = await genreFilter.openDropdown();
+        let filterDropdown: FilterDropdownComponent;
 
-        const option = dropdown.getOption('Романс');
-        await option.select();
-        expect(await option.isSelected()).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        const chip = filtersMenu.getActiveChip();
-        expect(await chip.isVisible()).toBe(true);
-        expect(await chip.getLabel()).toContain('1 обрано');
+        await allure.step('Open Genre filter dropdown', async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            filterDropdown = await genreFilter.openDropdown();
+        });
 
-        const badgeCount = await artistryPage.filterButton.getBadgeCount();
-        expect(badgeCount).toBe(1);
+        await allure.step('Select "Romance" option', async () => {
+            const option = filterDropdown.getOption(FilterOptions.ROMANCE);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
+
+        await allure.step('Verify chip label shows correct selection count', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(true);
+            expect(await chip.getLabel()).toContain(ChipText[currentLanguage].oneSelected);
+        });
+
+        await allure.step('Verify badge count is updated to 1', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+        });
     });
 
-    test('TC003 – Select multiple filter options', async ({artistryPage}) => {
+    test('TC003 – Select multiple filter options', async ({ artistryPage }) => {
         await allure.description('Verify multiple filters update the badge count correctly.');
         await allure.label('feature', 'Filters');
         await allure.parameter('Component', 'Genre + Year Filters');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
 
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const dropdown = await genreFilter.openDropdown();
-        const artSongOption = dropdown.getOption('Мистецька пісня');
-        await artSongOption.select();
-        expect(await artSongOption.isSelected()).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        const chip = filtersMenu.getActiveChip();
-        expect(await chip.isVisible()).toBe(true);
-        expect(await chip.getLabel()).toContain('1 обрано');
+        await allure.step('Select option from Genre filter', async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            const dropdown = await genreFilter.openDropdown();
+            const option = dropdown.getOption(FilterOptions.ART_SONG);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
 
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Verify chip label shows correct selection count', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(true);
+            expect(await chip.getLabel()).toContain(ChipText[currentLanguage].oneSelected);
+        });
 
-        const yearFilter = filtersMenu.getYearFilter('Рік');
-        await yearFilter.setYearRange('1918', '1950');
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Close Genre dropdown', async () => {
+             await filtersMenu.closeOpenedDropdown();
+             expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        await allure.step('Set year range in Year filter', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            await yearFilter.setYearRange('1918', '1950');
+            await filtersMenu.closeOpenedDropdown();
+        });
+
+        await allure.step('Verify badge count is updated to 2', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        });
     });
 
-    test('TC004 – Clear one selected filter', async ({artistryPage}) => {
+    test('TC004 – Clear one selected filter', async ({ artistryPage }) => {
         await allure.description('Verify clearing a single selected filter resets state.');
         await allure.label('feature', 'Filters');
         await allure.parameter('Component', 'Genre Filter');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const dropdown = await genreFilter.openDropdown();
+        let option: FilterOptionItemComponent;
 
-        const romanceOption = dropdown.getOption('Романс');
-        await romanceOption.select();
-        expect(await romanceOption.isSelected()).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        await dropdown.clear();
-        expect(await romanceOption.isSelected()).toBe(false);
-        await filtersMenu.page.waitForTimeout(500);
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        await allure.step('Select option from Genre filter', async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            const dropdown = await genreFilter.openDropdown();
+            option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
+
+        await allure.step('Clear selected option from dropdown', async () => {
+            await option.deselect();
+            expect(await option.isSelected()).toBe(false);
+        });
+
+        await allure.step('Verify chip label is hidden after clearing selection', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(false);
+        });
+
+        await allure.step('Verify badge is hidden after clearing selection', async () => {
+            await filtersMenu.page.waitForTimeout(500);
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
     });
 
     test('TC005 – Clear all selected filters', async ({artistryPage}) => {
@@ -100,26 +155,48 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.parameter('Component', 'Filters Menu');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const genreDropdown = await genreFilter.openDropdown();
-        const romanceOption = genreDropdown.getOption('Романс');
 
-        await romanceOption.select();
-        expect(await romanceOption.isSelected()).toBe(true);
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        const yearFilter = filtersMenu.getYearFilter('Рік');
-        await yearFilter.setYearRange('1950', '1975');
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Select option from Genre filter', async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            const dropdown = await genreFilter.openDropdown();
+            const option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
 
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        await allure.step('Close Genre dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        await filtersMenu.clearAllFilters();
-        await filtersMenu.page.waitForTimeout(500);
+        await allure.step('Set year range in Year filter', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            await yearFilter.setYearRange('1950', '1975');
+            await filtersMenu.closeOpenedDropdown();
+        });
 
-        const chip = filtersMenu.getActiveChip();
-        expect(await chip.isVisible()).toBe(false);
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        await allure.step('Verify badge count is updated to 2', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        });
+
+       await allure.step('Clear all selected filters', async () => {
+            await filtersMenu.page.waitForTimeout(500);
+            await filtersMenu.clearAllFilters();
+            await filtersMenu.page.waitForTimeout(500);
+        });
+
+        await allure.step('Verify chip label is hidden after clearing selection', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(false);
+        })
+        await allure.step('Verify badge is hidden after clearing selection', async () => {
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
     });
 
     test('TC006 – Verify no active filters by default', async ({artistryPage}) => {
@@ -127,7 +204,9 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.label('feature', 'Filters');
         await allure.parameter('Component', 'Filter Button');
 
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        await allure.step('Verify badge is hidden after clearing selection', async () => {
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
     });
 
     test('TC007 – Verify badge count updates dynamically', async ({artistryPage}) => {
@@ -136,30 +215,71 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.parameter('Component', 'Badge Count');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const genreDropdown = await genreFilter.openDropdown();
-        const romanceOption = genreDropdown.getOption('Романс');
 
-        await romanceOption.select();
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        const yearFilter = filtersMenu.getYearFilter('Рік');
-        await yearFilter.setYearRange('1950', '1975');
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Select option from Genre filter', async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            const dropdown = await genreFilter.openDropdown();
+            const option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
 
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        await allure.step('Close Genre dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        await genreFilter.openDropdown();
-        await romanceOption.deselect();
-        await filtersMenu.closeOpenedDropdown();
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+        await allure.step('Set year range in Year filter', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            await yearFilter.setYearRange('1950', '1975');
+            await filtersMenu.closeOpenedDropdown();
+        });
 
-        await yearFilter.openDropdown();
-        await yearFilter.clear();
-        await filtersMenu.closeOpenedDropdown();
-        await filtersMenu.page.waitForTimeout(500);
+        await allure.step('Verify badge count is updated to 2', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        });
 
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        await allure.step('Open Genre dropdown and clear selected before option', async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            const dropdown = await genreFilter.openDropdown();
+            const option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.deselect();
+            expect(await option.isSelected()).toBe(false);
+        });
+
+        await allure.step('Close Genre dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Verify badge count is updated to 1', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+        });
+
+        await allure.step('Open Year filter dropdown', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Click "Clear filter" button in Year filter', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.clickClearFilterButton();
+        });
+
+        await allure.step('Close Year filter dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            await filtersMenu.page.waitForTimeout(500);
+        });
+
+        await allure.step('Verify badge is hidden after clearing selection', async () => {
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
     });
 
     test('TC008 – Validate chip count updates correctly', async ({artistryPage}) => {
@@ -168,27 +288,48 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.parameter('Component', 'Chip');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const dropdown = await genreFilter.openDropdown();
+        let dropdown:FilterDropdownComponent;
+        let option:FilterOptionItemComponent;
 
-        const romanceOption = dropdown.getOption('Романс');
-        await romanceOption.select();
-        expect(await romanceOption.isSelected()).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        const chip = genreFilter.getChip();
-        expect(await chip.isVisible()).toBe(true);
-        expect(await chip.getLabel()).toContain('1 обрано');
+        await allure.step("Select 'Romance' option from Genre filter", async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            dropdown = await genreFilter.openDropdown();
+            option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
 
-        const artSongOption = dropdown.getOption('Мистецька пісня');
-        await artSongOption.select();
-        expect(await artSongOption.isSelected()).toBe(true);
-        expect(await chip.getLabel()).toContain('2 обрано');
+        await allure.step('Verify chip label shows correct selection count', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(true);
+            expect(await chip.getLabel()).toContain(ChipText[currentLanguage].oneSelected);
+        });
 
-        await romanceOption.deselect();
-        expect(await chip.getLabel()).toContain('1 обрано');
+        await allure.step("Select 'Art song' option from Genre filter", async () => {
+            const option = dropdown.getOption(FilterOptions.ART_SONG);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
+        await allure.step('Verify chip label shows correct selection count', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(true);
+            expect(await chip.getLabel()).toContain(ChipText[currentLanguage].twoSelected);
+        });
 
-        await artSongOption.deselect();
-        expect(await chip.isVisible()).toBe(false);
+        await allure.step('Clear selected option from dropdown', async () => {
+            await option.deselect();
+            expect(await option.isSelected()).toBe(false);
+        });
+
+        await allure.step('Verify chip label shows correct selection count', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(true);
+            expect(await chip.getLabel()).toContain(ChipText[currentLanguage].oneSelected);
+        });
     });
 
     test('TC009 – Year range valid', async ({artistryPage}) => {
@@ -197,11 +338,22 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.parameter('Component', 'Year Filter');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const yearFilter = filtersMenu.getYearFilter('Рік');
-        await yearFilter.setYearRange('1919', '1997');
-        await filtersMenu.closeOpenedDropdown();
+        let yearFilter: FilterYearItemComponent;
 
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Set year range in Year filter', async () => {
+            yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            await yearFilter.setYearRange('1919', '1997');
+            await filtersMenu.closeOpenedDropdown();
+        });
+
+        await allure.step('Verify badge count is updated to 1', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+         });
     });
 
     test('TC010 – Year range invalid', async ({artistryPage}) => {
@@ -210,102 +362,239 @@ test.describe('UI – Artistry Page Filters', () => {
         await allure.parameter('Component', 'Year Filter');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const yearFilter = filtersMenu.getYearFilter('Рік');
+        let yearFilter: FilterYearItemComponent;
 
-        await yearFilter.setYearRange('1918', '1999');
-        expect(await yearFilter.isValidationMessageVisible('Від')).toBe(false);
-        expect(await yearFilter.isValidationMessageVisible('До')).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        await yearFilter.updateFromInput('1917');
-        await yearFilter.updateToInput('1998');
-        expect(await yearFilter.isValidationMessageVisible('Від')).toBe(true);
-        expect(await yearFilter.isValidationMessageVisible('До')).toBe(false);
+        await allure.step('Open Year filter dropdown', async () => {
+            yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            expect(await yearFilter.isVisible()).toBe(true);
+        });
 
-        await yearFilter.updateFromInput('1917');
-        await yearFilter.updateToInput('1999');
-        expect(await yearFilter.isValidationMessageVisible('Від')).toBe(true);
-        expect(await yearFilter.isValidationMessageVisible('До')).toBe(true);
+        await allure.step('Enter valid "From" year and invalid "To" year', async () => {
+            await yearFilter.updateFromInput('1918');
+            await yearFilter.updateToInput('1999');
+            expect(await yearFilter.isToValidationMessageVisible()).toBe(true);
+        });
 
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        await allure.step('Verify  validation message for "To" field is present', async () => {
+            expect(await yearFilter.isToValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify text of "To" validation message', async () => {
+            expect(await yearFilter.getToValidationText()).toBe(ValidationMessages[currentLanguage].TO_GREATER_THAN_MAX);
+        });
+
+        await allure.step('Enter invalid "From" year and valid "To" year', async () => {
+            await yearFilter.updateFromInput('1917');
+            await yearFilter.updateToInput('1998');
+            expect(await yearFilter.isFromValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify  validation message for "From" field is present', async () => {
+            expect(await yearFilter.isFromValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify text of "From" validation message', async () => {
+            expect(await yearFilter.getFromValidationText()).toBe(ValidationMessages[currentLanguage].FROM_LESS_THAN_MIN);
+        });
+
+        await allure.step('Enter invalid "From" year and invalid "To" year', async () => {
+            await yearFilter.updateFromInput('1917');
+            await yearFilter.updateToInput('1999');
+            expect(await yearFilter.isFromValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify  validation message for "From" field is present', async () => {
+            expect(await yearFilter.isFromValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify text of "From" validation message', async () => {
+            expect(await yearFilter.getFromValidationText()).toBe(ValidationMessages[currentLanguage].FROM_LESS_THAN_MIN);
+        });
+
+        await allure.step('Verify  validation message for "To" field is present', async () => {
+            expect(await yearFilter.isToValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify text of "To" validation message', async () => {
+            expect(await yearFilter.getToValidationText()).toBe(ValidationMessages[currentLanguage].TO_GREATER_THAN_MAX);
+        });
+
+        await allure.step('Verify badge is hidden after invalid inputs', async () => {
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
     });
 
-    test('TC011 – Validation: Year range accepts only numeric values', async ({artistryPage}) => {
+    test('TC011 – Validation: Year range accepts only numeric values', async ({ artistryPage }) => {
         await allure.description('Verify year filter fields only accept numeric values.');
         await allure.label('feature', 'Filters');
         await allure.parameter('Component', 'Year Filter');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const yearFilter = filtersMenu.getYearFilter('Рік');
-        await yearFilter.setYearRange('abc', 'xyz');
+        let yearFilter: FilterYearItemComponent;
 
-        expect(await yearFilter.isValidationMessageVisible('Від')).toBe(true);
-        expect(await yearFilter.isValidationMessageVisible('До')).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        await yearFilter.clear();
-        expect(await yearFilter.getFromValue()).toBe('1918');
-        expect(await yearFilter.getToValue()).toBe('1998');
-        expect(await yearFilter.isValidationMessageVisible('Від')).toBe(false);
-        expect(await yearFilter.isValidationMessageVisible('До')).toBe(false);
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        await allure.step('Open Year filter dropdown', async () => {
+            yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            expect(await yearFilter.isVisible()).toBe(true);
+        });
+
+        await allure.step('Enter numeric values in "From" and "To" year fields', async () => {
+            await yearFilter.updateFromInput('abc');
+            await yearFilter.updateToInput('xyz');
+            expect(await yearFilter.isFromValidationMessageVisible()).toBe(true);
+        });
+
+        await allure.step('Verify  validation message for "From" field is present', async () => {
+            expect(await yearFilter.isToValidationMessageVisible()).toBe(true);
+        });
+        await allure.step('Verify text of "From" validation message', async () => {
+            expect(await yearFilter.getToValidationText()).toBe(ValidationMessages[currentLanguage].NUMERIC_ONLY);
+        });
+
+        await allure.step('Verify  validation message for "To" field is present', async () => {
+            expect(await yearFilter.isToValidationMessageVisible()).toBe(true);
+        });
+        await allure.step('Verify text of "To" validation message', async () => {
+            expect(await yearFilter.getToValidationText()).toBe(ValidationMessages[currentLanguage].NUMERIC_ONLY);
+        });
+
+        await allure.step('Verify badge is hidden after invalid inputs', async () => {
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
     });
 
-    test('TC012 – Dropdown visibility toggle', async ({artistryPage}) => {
+    test('TC012 – Open and close filter dropdown', async ({artistryPage}) => {
         await allure.description('Check that dropdown opens and closes correctly.');
         await allure.label('feature', 'Filters');
         await allure.parameter('Component', 'Dropdown');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const genreFilter = filtersMenu.getListFilter('Жанр');
 
-        await genreFilter.openDropdown();
-        expect(await genreFilter.isDropdownVisible()).toBe(true);
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        await filtersMenu.closeOpenedDropdown();
-        expect(await genreFilter.isDropdownVisible()).toBe(false);
+        await allure.step("Open Genre filter dropdown", async () => {
+            const genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            await genreFilter.openDropdown();
+            expect(await genreFilter.isDropdownVisible()).toBe(true);
+        });
+
+        await allure.step('Close Genre dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
     });
 
-    test('TC013 – Trash icon hidden when no filters selected', async ({artistryPage}) => {
+    test('TC013 – "Clear All filters" (trash icon) button hidden when no filters selected', async ({artistryPage}) => {
         await allure.description('Ensure "Clear all filters" icon is hidden when no filters are active.');
         await allure.label('feature', 'Filters');
         await allure.parameter('Component', 'Clear All Button');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        expect(await filtersMenu.isClearAllButtonVisible()).toBe(false);
+
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Verify Clear All button is hidden', async () => {
+            expect(await filtersMenu.isClearAllButtonVisible()).toBe(false);
+        });
     });
 
-    test('TC014 – Combined interaction flow', async ({artistryPage}) => {
-        await allure.description('Verify full user interaction flow across multiple filters.');
+    test('TC014 – Combined interaction flow', async ({ artistryPage }) => {
+        await allure.description('Verify full user interaction flow across multiple filters components.');
         await allure.label('feature', 'Filters');
         await allure.label('severity', 'critical');
-        await allure.parameter('Component', 'Combined Filters Flow');
+        await allure.parameter('Component', 'All');
 
         const filtersMenu = await artistryPage.filterButton.openFiltersMenu();
-        const genreFilter = filtersMenu.getListFilter('Жанр');
-        const genreDropdown = await genreFilter.openDropdown();
-        const romanceOption = genreDropdown.getOption('Романс');
+        let dropdown: FilterDropdownComponent;
+        let genreFilter:FilterListItemComponent;
 
-        await romanceOption.select();
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Verify Filters menu is visible', async () => {
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
 
-        const yearFilter = filtersMenu.getYearFilter('Рік');
-        await yearFilter.setYearRange('1950', '1975');
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Select option from Genre filter', async () => {
+            genreFilter = filtersMenu.getListFilter(FilterNames.GENRE);
+            dropdown = await genreFilter.openDropdown();
+            const option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.select();
+            expect(await option.isSelected()).toBe(true);
+        });
 
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        await allure.step('Close Genre dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            await filtersMenu.page.waitForTimeout(500);
+        });
 
-        const activeChipLabel = await filtersMenu.getActiveChipLabel();
-        expect(activeChipLabel).toContain('1 обрано');
+        await allure.step('Verify chip label shows correct selection count', async () => {
+            const chip = filtersMenu.getActiveChip();
+            expect(await chip.isVisible()).toBe(true);
+            expect(await chip.getLabel()).toContain(ChipText[currentLanguage].oneSelected);
+        });
 
-        await genreFilter.openDropdown();
-        await genreDropdown.clear();
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Verify badge count is updated to 1', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
 
-        expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+        });
 
-        await yearFilter.openDropdown();
-        await yearFilter.clear();
-        await filtersMenu.closeOpenedDropdown();
+        await allure.step('Set year range in Year filter', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            expect(await yearFilter.isVisible()).toBe(true);
+            await yearFilter.setYearRange('1918', '1950');
+            await filtersMenu.closeOpenedDropdown();
+        });
 
-        expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
-    });
+        await allure.step('Verify badge count is updated to 2', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(2);
+        });
+
+        await allure.step("Open Genre filter an deselect 'Romance' option", async () => {
+            filtersMenu.getListFilter(FilterNames.GENRE);
+            await genreFilter.openDropdown();
+            const option = dropdown.getOption(FilterOptions.ROMANCE);
+            await option.deselect();
+            expect(await option.isSelected()).toBe(false);
+        });
+
+        await allure.step('Close Genre dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Verify badge count is updated to 1', async () => {
+            expect(await artistryPage.filterButton.getBadgeCount()).toBe(1);
+        });
+        await allure.step('Open Year filter dropdown', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.openDropdown();
+            expect(await filtersMenu.isVisible()).toBe(true);
+        });
+
+        await allure.step('Click "Clear filter" button in Year filter', async () => {
+            const yearFilter = filtersMenu.getYearFilter();
+            await yearFilter.clickClearFilterButton();
+        });
+
+        await allure.step('Close Year filter dropdown', async () => {
+            await filtersMenu.closeOpenedDropdown();
+        });
+
+        await allure.step('Verify badge is hidden after clearing selection', async () => {
+            await filtersMenu.page.waitForTimeout(500);
+            expect(await artistryPage.filterButton.isBadgeHidden()).toBe(true);
+        });
+   });
 });


### PR DESCRIPTION
- Replaced unstable selectors with data-testid locators where it was possible.
- Removed magic numbers and hardcoded values from tests  (moved to constants/enums)
- Improved Allure step structure in filter tests
- Added click action in waitForHeaderChangeLangBtnVisible() within HeaderChangeLangBtn component to open the language dropdown.